### PR TITLE
Use FFI::MemoryPointer from_string for Ssdeep.from_string

### DIFF
--- a/lib/ffi/ssdeep.rb
+++ b/lib/ffi/ssdeep.rb
@@ -36,8 +36,7 @@ module Ssdeep
   # @raise HashError  
   #   An exception is raised if the libfuzzy library encounters an error.
   def self.from_string(buf)
-    bufp = FFI::MemoryPointer.new(buf.size)
-    bufp.write_string(buf, buf.size)
+    bufp = FFI::MemoryPointer.from_string(buf.size)
 
     out = FFI::MemoryPointer.new(FUZZY_MAX_RESULT)
 


### PR DESCRIPTION
Previously this code was using the string's size in characters NOT its size in bytes to determine how many bytes to copy into buf.  By using the FFI::MemoryPointer.from_string method this takes care of string encoding so that all of the string's bytes are copied.
